### PR TITLE
Added State.GetServers() returning slice of all servers

### DIFF
--- a/state.go
+++ b/state.go
@@ -88,9 +88,18 @@ type State struct {
 	trackBulkAPICalls bool
 }
 
-/*
-	Getter functions
-*/
+/*Getter functions*/
+
+func (s *State) GetServers() []*Server {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]*Server, 0, len(s.servers))
+	for _, srv := range s.servers {
+		result = append(result, srv)
+	}
+	return result
+}
 
 func (s *State) Self() *User {
 	s.mu.RLock()


### PR DESCRIPTION
Returns a slice of all cached Server objects.
Useful for determining the originating server of a message.

## Summary by Sourcery

New Features:
- Expose a State.GetServers method that returns a slice of all cached Server objects.